### PR TITLE
Fix creative tab layout when opening in Craftables mode

### DIFF
--- a/common/src/main/java/com/evandev/remi/mixin/emi/EmiScreenManagerMixin.java
+++ b/common/src/main/java/com/evandev/remi/mixin/emi/EmiScreenManagerMixin.java
@@ -68,7 +68,7 @@ public abstract class EmiScreenManagerMixin {
     @ModifyVariable(at = @At(value = "STORE", ordinal = 0), method = "createScreenSpace", name = "headerOffset")
     private static int modifyHeaderOffset(int headerOffset, EmiScreenManager.SidebarPanel panel, Screen screen,
                                           List<Bounds> exclusion) {
-        if (panel.getType() == SidebarType.INDEX && ReliableEmiConfig.enableCreativeModeTabs) {
+        if (panel.supportsType(SidebarType.INDEX) && ReliableEmiConfig.enableCreativeModeTabs) {
             if (CreativeModeTabGui.currentTheme() == CreativeModeTabGui.TabTheme.DEFAULT) {
                 return headerOffset + CreativeModeTabGui.CREATIVE_MODE_TAB_HEIGHT;
             }
@@ -255,7 +255,7 @@ public abstract class EmiScreenManagerMixin {
 
     @ModifyVariable(at = @At("HEAD"), method = "createScreenSpace", argsOnly = true)
     private static Bounds modifyEmixxBounds(Bounds bounds, EmiScreenManager.SidebarPanel panel) {
-        if (panel.getType() == SidebarType.INDEX && ReliableEmiConfig.enableCreativeModeTabs) {
+        if (panel.supportsType(SidebarType.INDEX) && ReliableEmiConfig.enableCreativeModeTabs) {
             if (CreativeModeTabGui.currentTheme() == CreativeModeTabGui.TabTheme.VANILLA) {
                 int tabSpace = 35;
                 return new Bounds(


### PR DESCRIPTION
Fixes creative tabs being rendered outside the screen when the inventory is reopened with the Craftables sidebar selected.

Related to #57 — the previous fix initialized tabs when the panel supports `INDEX`, but layout still reserved space only when the active type was `INDEX`. Both layout checks now use `supportsType(SidebarType.INDEX)`.

### Before
<img width="516" height="257" alt="Telegram 2026-08-06 02 40 16" src="https://github.com/user-attachments/assets/ce91678c-64b1-40fd-a9df-182b082ab4dd" />

### Tested
Minecraft 1.21.1 with NeoForge and Reliable EMI 4.0.3.